### PR TITLE
Fix error introduced by 2ba45ba85fafec0b17dd9c74abc2f48e9b7031f1

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -251,7 +251,7 @@ update_or_clone "$puppetgit" puppet-module
 git --git-dir=puppet-module/.git rev-parse HEAD > $TOP/etc/config-tools/puppet-module-rev
 
 if [ -n "$tag" -a "$tagged" = 1 ]; then
-    sed -i -e "s/master/$(cat puppet-module-rev)/" ./puppet-module/Puppetfile
+    sed -i -e "s/master/$(cat ${TOP}/etc/config-tools/puppet-module-rev)/" ./puppet-module/Puppetfile
 fi
 
 if [ "$LOCAL" != 1 ]; then


### PR DESCRIPTION
When you launch provision.sh this script stop on r10k error.

```
[R10K::TaskRunner - ERROR] Task #<R10K::Task::Module::Sync:0x00000002e2d720> failed while running:  at /home/gael/.r10k/git/git---github.com-enovance-puppet-openstack-cloud.git. (Does the remote repository need to be updated?)
```

The puppet-module/Puppetfile file seems not good :

```
mod 'cloud',
  :git => 'git://github.com/enovance/puppet-openstack-cloud.git',
  :ref => ''
```

The problem is :

```
+ git --git-dir=puppet-module/.git rev-parse HEAD
+ '[' -n I.1.1.0 -a 1 = 1 ']'
++ cat puppet-module-rev
cat: puppet-module-rev: Aucun fichier ou dossier de ce type
+ sed -i -e s/master// ./puppet-module/Puppetfile
```

The puppet-module-rev file has been moved by the following commit :
- https://github.com/enovance/config-tools/commit/2ba45ba85fafec0b17dd9c74abc2f48e9b7031f1
