### PR TITLE
Fix forgotten $CDIR in configure

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -73,7 +73,7 @@ for f in /etc/serverspec/arch.yml.tmpl /etc/puppet/data/common.yaml.tmpl /etc/pu
     fi
 done
 
-generate 0 /etc/config-tools/config
+generate 0 $CDIR/config
 
 . $CDIR/config
 


### PR DESCRIPTION
```
CDIR=/etc/config-tools
-generate 0 /etc/config-tools/config
+generate 0 $CDIR/config
. $CDIR/config
```
