### PR TITLE
extract-archive.sh: fall back to a copy if hard linking doesn't work

### DIFF
--- a/extract-archive.sh
+++ b/extract-archive.sh
@@ -74,7 +74,8 @@ for version in $(ls -d *-*); do
 done
 
 # allow to boot over http
-ln -f /var/lib/tftpboot/{vmlinuz,initrd.pxe,health.pxe} /var/www/install/ || :
+ln -f /var/lib/tftpboot/{vmlinuz,initrd.pxe,health.pxe} /var/www/install/ || \
+  cp -f /var/lib/tftpboot/{vmlinuz,initrd.pxe,health.pxe} /var/www/install/ || :
 
 # for RHEL www hierarchy compatibility
 if [ -d /var/www/html ]; then


### PR DESCRIPTION
This allows for the case where /var/lib/tftpboot and /var/www/install aren't on the same filesystem
