### PR TITLE
hiera: add another source for secrets

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -199,6 +199,7 @@ EOF
   - "%{::type}/%{::fqdn}"
   - "%{::type}/common"
   - common
+  - secrets
 EOF
 chown puppet:puppet /etc/puppet/hiera.yaml
 


### PR DESCRIPTION
This allows to set the passwords in a file eventually out of source
control or generate it from any kind of vault on the install server.

Fixes #24
