### PR TITLE
Rename file with extensions .yml to .yaml for uniformity

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -33,7 +33,7 @@ set -x
 LAST=$1
 
 CDIR=/etc/config-tools
-CFG=$CDIR/global.yml
+CFG=$CDIR/global.yaml
 
 LOGDIR=$WORKSPACE
 
@@ -71,7 +71,7 @@ generate() {
     chmod 0644 $file
 }
 
-for f in /etc/serverspec/arch.yml.tmpl /etc/puppet/data/common.yaml.tmpl /etc/puppet/data/fqdn.yaml.tmpl /etc/puppet/data/type.yaml.tmpl $CFG $CDIR/config.tmpl; do
+for f in /etc/serverspec/arch.yaml.tmpl /etc/puppet/data/common.yaml.tmpl /etc/puppet/data/fqdn.yaml.tmpl /etc/puppet/data/type.yaml.tmpl $CFG $CDIR/config.tmpl; do
     if [ ! -r $f ]; then
         echo "$f doesn't exist" 1>&2
         exit 1

--- a/download.sh
+++ b/download.sh
@@ -137,7 +137,7 @@ puppetgit=$($ORIG/extract.py module "$yamlfile")
 puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$version/")
 serverspecgit=$($ORIG/extract.py serverspec "$yamlfile")
 env=$($ORIG/extract.py environment "$yamlfile")
-envyml=${env}.yml
+envyml=${env}.yaml
 infragit=$($ORIG/extract.py infrastructure "$yamlfile")
 
 # allow to have an empty fields (optional)
@@ -188,9 +188,9 @@ TOP=$(pwd)/top
 rm -rf $TOP
 mkdir -p $TOP/etc/config-tools $TOP/etc/puppet/manifests $TOP/usr/sbin $TOP/usr/bin
 
-$ORIG/merge.py $infrayaml env/$envyml > $TOP/etc/config-tools/global.yml
+$ORIG/merge.py $infrayaml env/$envyml > $TOP/etc/config-tools/global.yaml
 
-$ORIG/generate.py 0 $TOP/etc/config-tools/global.yml $ORIG/config.tmpl version=$version role=$role > $TOP/etc/config-tools/config
+$ORIG/generate.py 0 $TOP/etc/config-tools/global.yaml $ORIG/config.tmpl version=$version role=$role > $TOP/etc/config-tools/config
 . $TOP/etc/config-tools/config
 
 if [ -z "$USER" ]; then
@@ -234,7 +234,7 @@ if [ -d env/$env ]; then
 
     mkdir -p $TOP/var/www/install/$version
     # TODO: make the list of roles generic
-    for role in $($ORIG/extract.py -a 'profiles.*.edeploy' $TOP/etc/config-tools/global.yml|fgrep -v install-server|sort -u); do
+    for role in $($ORIG/extract.py -a 'profiles.*.edeploy' $TOP/etc/config-tools/global.yaml|fgrep -v install-server|sort -u); do
         (cd $ORIG/cache/$version
          check_and_download $edeployurl/$role-$version.edeploy
          cp $role-$version.edeploy* $TOP/var/www/install/$version/
@@ -286,7 +286,7 @@ fi
 # hosts
 
 if [ -r $ORIG/infra/hosts.tmpl ]; then
-    $ORIG/generate.py 0 $TOP/etc/config-tools/global.yml $ORIG/infra/hosts.tmpl > $TOP/etc/hosts
+    $ORIG/generate.py 0 $TOP/etc/config-tools/global.yaml $ORIG/infra/hosts.tmpl > $TOP/etc/hosts
 fi
 
 # Puppet modules
@@ -312,7 +312,7 @@ update_or_clone "$serverspecgit" serverspec
 
 git --git-dir=serverspec/.git rev-parse HEAD > $TOP/etc/config-tools/serverspec-rev
 
-cp infra/arch.yml.tmpl serverspec/
+cp infra/arch.yaml.tmpl serverspec/
 sed -i "s/root/$USER/" serverspec/spec/spec_helper.rb
 
 cp -a serverspec $TOP/etc/
@@ -326,10 +326,10 @@ cp $ORIG/configure.sh $ORIG/verify-servers.sh $ORIG/generate.py $ORIG/merge.py $
 cp $ORIG/config.tmpl $TOP/etc/config-tools/
 
 if [ -r infra/openrc.sh.tmpl ]; then
-    $ORIG/generate.py 0 $TOP/etc/config-tools/global.yml infra/openrc.sh.tmpl > $TOP/etc/config-tools/openrc.sh
+    $ORIG/generate.py 0 $TOP/etc/config-tools/global.yaml infra/openrc.sh.tmpl > $TOP/etc/config-tools/openrc.sh
 fi
 
-(cd $TOP; find . -name '*.tmpl'|sed -e 's@^\.@@' -e 's@.tmpl$@@'|egrep -v '/etc/puppet/data/fqdn.yaml|/etc/puppet/data/type.yaml|/etc/serverspec/arch.yml.tmpl|/etc/config-tools/config.tmpl') > $TOP/etc/config-tools/templates
+(cd $TOP; find . -name '*.tmpl'|sed -e 's@^\.@@' -e 's@.tmpl$@@'|egrep -v '/etc/puppet/data/fqdn.yaml|/etc/puppet/data/type.yaml|/etc/serverspec/arch.yaml.tmpl|/etc/config-tools/config.tmpl') > $TOP/etc/config-tools/templates
 
 # create the archive
 

--- a/inception.sh
+++ b/inception.sh
@@ -73,7 +73,7 @@ done
 # Get config from deployment file
 
 ${ORIG}/download.sh $flag $release $deployfile version=$dist-$release
-CFG=./top/etc/config-tools/global.yml
+CFG=./top/etc/config-tools/global.yaml
 
 if [ ! -d top/etc/config-tools/infra ]; then
     mkdir top/etc/config-tools/infra

--- a/verify-servers.sh
+++ b/verify-servers.sh
@@ -30,7 +30,7 @@ if ! type -p rspec > /dev/null; then
 fi
 
 CDIR=/etc/config-tools
-CFG=$CDIR/global.yml
+CFG=$CDIR/global.yaml
 
 . $CDIR/config
 
@@ -64,7 +64,7 @@ if [ -z "$step" ]; then
     step=100
 fi
 
-generate.py $step $CFG /etc/serverspec/arch.yml.tmpl|grep -v '^$' > /etc/serverspec/arch.yml
+generate.py $step $CFG /etc/serverspec/arch.yaml.tmpl|grep -v '^$' > /etc/serverspec/arch.yaml
 
 cd /etc/serverspec
 


### PR DESCRIPTION
In order to have the same naming conventions across all our code the .yaml extensions will be used across all files.
