### PR TITLE
puppet/init.pp: add hiera_resources

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -164,6 +164,7 @@ Exec {
   path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
 }
 hiera_include('classes')
+hiera_resources('resources')
 EOF
          cat > /etc/facter/facts.d/environment.txt <<EOF
 type=${PROF_BY_HOST[$h]}
@@ -176,6 +177,7 @@ Exec {
   path => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
 }
 hiera_include('classes')
+hiera_resources('resources')
 EOF
         tee /tmp/environment.txt.$h <<EOF
 type=${PROF_BY_HOST[$h]}

--- a/download.sh
+++ b/download.sh
@@ -295,6 +295,7 @@ Exec {
 }
 
 hiera_include('classes')
+hiera_resources('resources')
 EOF
 
 # Ansible


### PR DESCRIPTION
hiera_resources allows to use hiera to declare arbitrary resources as we
already do for classes using hiera-include.

depends on the hiera_include module added in
redhat-openstack/openstack-puppet-modules#267
